### PR TITLE
feat: version WHOOP wellness context handoff

### DIFF
--- a/scripts/summary-fixture-test.mjs
+++ b/scripts/summary-fixture-test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { buildDailySummary, buildWeeklySummary } from '../dist/services/summary.js';
-import { buildWellnessContext } from '../dist/services/context.js';
+import { buildWellnessContext, formatWellnessContextMarkdown } from '../dist/services/context.js';
 
 const minute = 60 * 1000;
 const hour = 60 * minute;
@@ -105,10 +105,16 @@ assert.ok(weekly.diagnostic.action_candidates.length >= 3);
 
 const context = await buildWellnessContext(fakeClient, { days: 10, timezone: 'UTC' });
 assert.equal(context.source, 'whoop');
+assert.equal(context.context_contract_version, 'delx-wellness-context/v1');
+assert.equal(context.context_type, 'wellness_context');
+assert.equal(context.recommended_handoff.tool, 'exercise_catalog_recommend_session');
 assert.equal(context.recovery_score, 82);
 assert.equal(context.sleep_score, 86);
 assert.equal(context.strain_score, 11.5);
 assert.equal(context.recent_training_load, 'normal');
 assert.ok(context.telegram_summary.includes('WHOOP'));
+const contextMarkdown = formatWellnessContextMarkdown(context);
+assert.ok(contextMarkdown.includes('context_type'));
+assert.ok(contextMarkdown.includes('exercise_catalog_recommend_session'));
 
 console.log(JSON.stringify({ ok: true, daily: daily.kind, weekly: weekly.kind }, null, 2));

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -323,6 +323,8 @@ export const SummaryOutputSchema = z.object({
 
 export const WellnessContextOutputSchema = z.object({
   source: z.literal("whoop"),
+  context_contract_version: z.literal("delx-wellness-context/v1"),
+  context_type: z.literal("wellness_context"),
   generated_at: z.string(),
   recovery_score: z.number().min(0).max(100).optional(),
   sleep_score: z.number().min(0).max(100).optional(),
@@ -332,6 +334,7 @@ export const WellnessContextOutputSchema = z.object({
   injury_flags: z.array(z.string()),
   notes: z.array(z.string()),
   data_quality: z.unknown().optional(),
+  recommended_handoff: z.object({ tool: z.string(), reason: z.string() }).strict(),
   telegram_summary: z.string().optional()
 }).strict();
 

--- a/src/services/context.ts
+++ b/src/services/context.ts
@@ -44,6 +44,8 @@ export async function buildWellnessContext(client: Pick<WhoopClient, "list">, op
 
   return {
     source: "whoop",
+    context_contract_version: "delx-wellness-context/v1",
+    context_type: "wellness_context",
     generated_at: summary.generated_at,
     recovery_score: recoveryScore,
     sleep_score: sleepScore,
@@ -53,6 +55,10 @@ export async function buildWellnessContext(client: Pick<WhoopClient, "list">, op
     injury_flags: options.injury_flags ?? [],
     notes,
     data_quality: summary.data_quality,
+    recommended_handoff: {
+      tool: "exercise_catalog_recommend_session",
+      reason: "Use WHOOP recovery, sleep and strain to scale workout intensity and volume.",
+    },
     telegram_summary: [
       "WHOOP wellness context",
       recoveryScore !== undefined ? `Recovery: ${recoveryScore}` : undefined,
@@ -65,8 +71,14 @@ export async function buildWellnessContext(client: Pick<WhoopClient, "list">, op
 
 export function formatWellnessContextMarkdown(context: Record<string, unknown>): string {
   const lines = ["# WHOOP Wellness Context", ""];
-  for (const key of ["recovery_score", "sleep_score", "strain_score", "recent_training_load"]) {
+  for (const key of ["context_contract_version", "context_type", "recovery_score", "sleep_score", "strain_score", "recent_training_load"]) {
     if (context[key] !== undefined) lines.push(`- **${key}**: ${String(context[key])}`);
+  }
+  const handoff = record(context.recommended_handoff);
+  if (handoff.tool !== undefined || handoff.reason !== undefined) {
+    lines.push("", "## Recommended Handoff");
+    if (handoff.tool !== undefined) lines.push(`- **tool**: ${String(handoff.tool)}`);
+    if (handoff.reason !== undefined) lines.push(`- **reason**: ${String(handoff.reason)}`);
   }
   if (Array.isArray(context.notes) && context.notes.length) {
     lines.push("", "## Notes");


### PR DESCRIPTION
## Summary
- Adds `context_contract_version: delx-wellness-context/v1` and `context_type: wellness_context` to WHOOP normalized wellness context.
- Adds `recommended_handoff` pointing to `exercise_catalog_recommend_session`.
- Updates schema, markdown formatter, and fixture assertions for contract/Telegram parity.

## Test Plan
- `git diff --check`
- `npm run typecheck`
- `npm run build`
- `npm run test:summary`
- `npm test`
- focused secret-pattern scan over added lines

## Safety / Privacy
- No raw WHOOP payloads, OAuth tokens, refresh tokens, or local secrets added.
- Handoff metadata is static and privacy-safe.