### PR TITLE
docs: stop linking the archived Delx Agent Workbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 > ⚡ **One-command install** with [Delx Wellness for Hermes](https://github.com/davidmosiah/delx-wellness-hermes):
 > `npx -y delx-wellness-hermes setup` &mdash; preconfigures this connector and the full Delx Wellness stack in a dedicated Hermes profile.
 >
-> Or wire it standalone into Claude Desktop / Cursor / ChatGPT Desktop &mdash; see the install section below. Runnable examples live in the [Delx Agent Workbench](https://github.com/davidmosiah/delx-agent-workbench).
+> Or wire it standalone into Claude Desktop / Cursor / ChatGPT Desktop &mdash; see the install section below. Runnable examples live in the [Delx Wellness hub](https://github.com/davidmosiah/delx-wellness#run-it-in-your-agent).
 
 > **Public proof:** WHOOP MCP is tracked in the Delx [Open Source Growth Snapshot](https://github.com/davidmosiah/delx-wellness/blob/main/docs/open-source-growth-snapshot.md) alongside downloads, stars and next-action priorities. If it saves you OAuth and MCP setup time, star this repo so other recovery-focused agent builders can find it faster.
 >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Live docs were sending people to the archived `davidmosiah/delx-agent-workbench`. This PR points that sentence at a living target that already exists:

- Runnable Claude / Cursor / ChatGPT examples → [delx-wellness `#run-it-in-your-agent`](https://github.com/davidmosiah/delx-wellness#run-it-in-your-agent)

The unofficial WHOOP disclaimer is unchanged. No new URLs were invented.

## Safety

- [x] This keeps the project explicitly unofficial.
- [x] This does not use private/internal WHOOP APIs.
- [x] This does not expose OAuth tokens, client secrets or personal health data.
- [x] This preserves read-only behavior unless the change is explicitly about disconnect/revoke.

## Validation

- [x] `npm test` on this VM (`whoop-mcp-unofficial@0.6.3`, typecheck, build, smoke, HTTP smoke, fixture/contract suites)
- [x] Relevant docs updated
- Confirmed no remaining `delx-agent-workbench` / "Agent Workbench" hits in this repo

No GitHub Actions were added, enabled, or relied on.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b017b6a5-359f-4b0f-8576-2244ec7c9f45?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b017b6a5-359f-4b0f-8576-2244ec7c9f45&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the standalone setup instructions to link runnable examples to the Delx Wellness hub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->